### PR TITLE
Add prototype pattern in sim.py

### DIFF
--- a/covasim/sim.py
+++ b/covasim/sim.py
@@ -16,9 +16,21 @@ from . import plotting as cvplt
 from . import interventions as cvi
 from . import immunity as cvimm
 from . import analysis as cva
-
+import copy
 # Almost everything in this file is contained in the Sim class
 __all__ = ['Sim', 'diff_sims', 'demo', 'AlreadyRunError']
+
+
+class Prototype(object):
+    def __init__(self): 
+        self._objects = {}
+        
+    def clone(self):
+        pass
+ 
+    def deep_clone(self):
+        pass
+
 
 
 class Sim(cvb.BaseSim):
@@ -1303,6 +1315,17 @@ class Sim(cvb.BaseSim):
         '''
         fig = cvplt.plot_result(sim=self, key=key, *args, **kwargs)
         return fig
+
+    def clone(self):
+        return copy(self)
+ 
+    def deep_clone(self):
+        return deepcopy(self)
+
+
+
+
+
 
 
 def diff_sims(sim1, sim2, skip_key_diffs=False, output=False, die=False):


### PR DESCRIPTION
Please note: this PR is part of a school project.

**Why**
The prototype pattern is a creative design pattern that allows you to copy existing objects without making your code depend on the classes to which they belong. You can clone the generated prototype and avoid running the initialization code repeatedly. It is used to create duplicate objects while ensuring performance. This pattern is used when creating objects directly is expensive. Simplified object creation, while avoiding the constraints of the constructor, is not restricted by the constructor directly copy the object.

By trying to apply the prototype model to the simulation class.py, I hope to be able to improve the performance of the simulation runtime. Each time the user enters a set of parameters, perhaps only a single parameter change compared to the last time. Then it can replicate the results of the last simulation and only modify the corresponding parameters and don't have to do the whole thing all over again.

**What I change**
By importing the copy module to help us create a clone of an object. Deep and shallow clone functions are defined as copy.deepcopy() and copy.copy()